### PR TITLE
added workflow for closing old PRs

### DIFF
--- a/.github/workflows/close-old-pr.yml
+++ b/.github/workflows/close-old-pr.yml
@@ -1,0 +1,34 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close_stale_prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+  
+    steps:
+    - uses: actions/stale@v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR has been automatically closed due to inactivity from the owner for 15 days.'
+        days-before-pr-stale: 15
+        days-before-pr-close: 0
+        exempt-pr-author: false
+        exempt-pr-labels: ''
+        only-labels: ''
+        operations-per-run: 30
+        remove-stale-when-updated: true
+        debug-only: false


### PR DESCRIPTION
## Related Issue

Fixes #141 

## Description

Implemented a workflow that automatically closes old PRs based on predefined criteria, such as their last update timestamp. By regularly closing PRs that have not been updated within a certain timeframe, the repository can stay organized, and contributors can focus on active and relevant PRs.

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

