### PR TITLE
Fix search bar text visibility issue

### DIFF
--- a/src/Components/Container.css
+++ b/src/Components/Container.css
@@ -59,9 +59,9 @@
   font-size: 0.8rem;
 }
 .topContainer .inputBox input {
-  width: 100%;
+  width: auto;
   height: 100%;
-  /* padding: 0px 40px; */
+
   font-size: 16px;
   color: #d0cfd4;
   background: #75738045;


### PR DESCRIPTION
## Description
This pull request addresses a visibility issue with the search bar. The problem arose because the search bar was set to width: 100%, which caused the text input to become hidden or clipped.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
Before
![Screenshot 2024-10-11 115247](https://github.com/user-attachments/assets/9e0ade3f-58e0-44c5-b388-f83ce92c656d)
After
![Screenshot 2024-10-11 115312](https://github.com/user-attachments/assets/74d01411-a78b-4af9-a6e8-c8685ae20209)
![Screenshot 2024-10-11 115325](https://github.com/user-attachments/assets/5d96b6f0-2b72-4467-9be1-0f51042cc54a)

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
Please review the changes and let me know if there are any further adjustments needed. This fix should improve the user experience when interacting with the search functionality.
